### PR TITLE
Patch setup.py to skip AVX2 code generation

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,8 @@ package:
 source:
   url: https://github.com/PyTables/PyTables/archive/v{{ version }}.tar.gz
   sha256: 629a0227bb2b315c5d97629073696609eaee41d0fc89e03f997412613cd46d3a
+  patches:
+      - noavx2.patch
 
 build:
   number: 3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
       - noavx2.patch
 
 build:
-  number: 3
+  number: 4
   entry_points:
     - pt2to3 = tables.scripts.pt2to3:main
     - ptdump = tables.scripts.ptdump:main

--- a/recipe/noavx2.patch
+++ b/recipe/noavx2.patch
@@ -1,0 +1,20 @@
+diff --git a/setup.py b/setup.py
+index b5c55ba..d8671b4 100755
+--- a/setup.py
++++ b/setup.py
+@@ -848,15 +848,6 @@ if 'BLOSC' not in optional_libs:
+             CFLAGS.append('-msse2')
+         blosc_sources += [f for f in glob.glob('c-blosc/blosc/*.c')
+                           if 'sse2' in f]
+-    # AVX2
+-    # Detection code for AVX2 only works for gcc/clang, not for MSVC yet
+-    if ('avx2' in cpu_flags and
+-            compiler_has_flags(compiler, ["-mavx2"])):
+-                print('AVX2 detected')
+-                CFLAGS.append('-DSHUFFLE_AVX2_ENABLED')
+-                CFLAGS.append('-mavx2')
+-                blosc_sources += [f for f in glob.glob('c-blosc/blosc/*.c')
+-                                  if 'avx2' in f]
+ else:
+     ADDLIBS += ['blosc']
+ 


### PR DESCRIPTION
PyTables internal C-BLOSC will be built with AVX2 instructions when
AVX2 capabilities are detected. It is not easy to disable these flags
This needs to be fixed upstream. This patch is needed in the meantime.

Fixes #23