### PR TITLE
Update blosc2 patch to fix pip check

### DIFF
--- a/recipe/do_not_rely_on_python-blosc2.patch
+++ b/recipe/do_not_rely_on_python-blosc2.patch
@@ -1,3 +1,5 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index b503ab65..774ec525 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -12,7 +12,7 @@ requires = [
@@ -9,3 +11,12 @@
  ]
  build-backend = "setuptools.build_meta"
  # build-backend = "mesonpy"  # and replace ``setuptools`` above
+@@ -72,7 +72,7 @@ dependencies = [
+     "numexpr >= 2.6.2",
+     "packaging",
+     "py-cpuinfo",
+-    "blosc2 >= 2.3.0",
++    # "blosc2 >= 2.3.0",
+ ]
+ 
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - do_not_rely_on_python-blosc2.patch
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - pt2to3 = tables.scripts.pt2to3:main
     - ptdump = tables.scripts.ptdump:main


### PR DESCRIPTION
This PR closes #95 by updating the patch to remove `blosc2` from both the build and runtime requirements.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
