### PR TITLE
Rebuild using HDF5's nompi variant for maximum flexibility

### DIFF
--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -25,7 +25,7 @@ set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
 
 echo Downloading micromamba %MICROMAMBA_VERSION%
 if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MICROMAMBA_URL%', '%MICROMAMBA_EXE%')"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 echo Creating environment

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - do_not_rely_on_python-blosc2.patch
 
 build:
-  number: 3
+  number: 4
   entry_points:
     - pt2to3 = tables.scripts.pt2to3:main
     - ptdump = tables.scripts.ptdump:main
@@ -38,6 +38,9 @@ requirements:
     - bzip2
     - c-blosc2 >=2.14.4
     - hdf5
+    # Ensure that we build with nompi variant
+    # it provides downstream packages with the most flexibility
+    - hdf5 =*=nompi*
     - zlib
   run:
     - python


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Due to a bug in the build of the HDF5 1.14.6 conda package, linux-64 packages were built only for the mvapich MPI library, not for openmpi, mpich or nompi (conda-forge/hdf5-feedstock#258). Consequently pytables can only be installed with HDF5 1.14.6 on linux-64 if the mvapich MPI library is being used; if you run the following on an x86_64 Linux box:

```
conda search -i pytables |grep 'hdf5.*1.14.6' | sort -u
```

you will get the output

```
  - hdf5 >=1.14.6,<1.14.7.0a0 mpi_mvapich_*
```

This PR rebuilds pytables with HDF5 1.14.6. Since that package has now been fixed, pytables builds should now build against the nompi variant, which does not require downstream users to be using MPI. The PR also adds a requirement on nompi at build time so that this breakage cannot occur in future. This mirrors what the conda-forge admins did for the OpenCV package, see conda-forge/opencv-feedstock#468.